### PR TITLE
Add ability to hide post metadata

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -4,6 +4,9 @@ date: {{ .Date }}
 tags: []
 categories: []
 weight: 50
+showPublishDate: true
+showWordCount: true
+showReadingTime: true
 show_comments: true
 katex: false
 draft: true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -26,6 +26,9 @@ tabWidth = 4
 [params]
 description = "Example site for hugo-theme-flat"
 mainSections = ['posts']
+showPublishDate = true
+showWordCount = true
+showReadingTime = true
 
 ## uncomment belows and set proper values to enable remark42
 # [params.remark42]

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -3,14 +3,25 @@
 <section class="single">
     <h1 class="title">{{ .Title }}</h1>
 
+    {{ $showPublishDate := .Params.showPublishDate | default .Site.Params.showPublishDate | default true }}
+    {{ $showWordCount := .Params.showWordCount | default .Site.Params.showWordCount | default true }}
+    {{ $showReadingTime := .Params.showReadingTime | default .Site.Params.showReadingTime | default true }}
     <div class="tip">
+        {{ if $showPublishDate }}
         <time datetime="{{ .PublishDate }}">{{ .PublishDate.Format "2006/01/02" }}</time>
+        {{ end }}
+        {{ if $showWordCount }}
+        {{ if $showPublishDate }}
         <span class="split">·</span>
+        {{ end }}
         <span> {{ .WordCount }} words </span>
+        {{ end }}
+        {{ if $showReadingTime }}
+        {{ if or $showPublishDate $showWordCount }}
         <span class="split">·</span>
-        <span>
-            {{ .ReadingTime }} minutes to read
-        </span>
+        {{ end }}
+        <span> {{ .ReadingTime }} minutes to read </span>
+        {{end}}
     </div>
 
     <div class="taxonomies">


### PR DESCRIPTION
Currently, every page shows a publishing date, word count, and estimated reading time.
This PR adds both global site and per-page parameters that can hide each of these metadata from displaying. Default behavior remains unchanged.