### PR TITLE
Add ability to manually change light and dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ This is a theme I personally use.
 - Responsive layout
 - Sub-menu support
 
+## Dark & Light Theme Support
+
+By default, dark or light theme will be set according to CSS media query. You can for default light or dark theme as well as add a user-side theme toggle button by adding the following parameters to your config file.
+
+```toml
+[params]
+themeMode = "auto" # sets default theme, options are "auto", "dark", or "light"
+themeToggle = false # sets presence of theme toggle, options are "true" or "false"
+```
+
 ## Multi Section Supports
 
 If you use multi sections (with the concept from hugo), the RSS at bottom and *Recent* at side are ready for displaying those content. However, you will need to set up your menu at `config.toml` to point the hyperlink to proper destination.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -26,6 +26,8 @@ tabWidth = 4
 [params]
 description = "Example site for hugo-theme-flat"
 mainSections = ['posts']
+themeMode = "auto" # sets default theme, options are "auto", "dark", or "light"
+themeToggle = false # sets presence of theme toggle, options are "true" or "false"
 
 ## uncomment belows and set proper values to enable remark42
 # [params.remark42]
@@ -36,7 +38,6 @@ mainSections = ['posts']
 # locale='en'
 # show_email_subscription=false
 # simple_view=true
-
 
 # you can set multi row of footers like these
 [[params.footer_rows]]

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -77,4 +77,6 @@
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}" />
 <script src="{{ "js/copy-code-block.js" | relURL }}"></script>
 <link rel="shortcut icon" href="{{ "images/favicon.ico" | relURL }}" type="image/x-icon" />
+{{ if .Site.Params.themeToggle }}
 <script src="{{ "js/theme-toggle.js" | relURL }}"></script>
+{{ end }}

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -1,7 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,minimum-scale=1">
 
-
 {{ $title := .Site.Title -}}
 {{ if .Params.Title -}}
     {{ $title = printf "%s | %s" .Params.Title $title -}}
@@ -78,3 +77,4 @@
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}" />
 <script src="{{ "js/copy-code-block.js" | relURL }}"></script>
 <link rel="shortcut icon" href="{{ "images/favicon.ico" | relURL }}" type="image/x-icon" />
+<script src="{{ "js/theme-toggle.js" | relURL }}"></script>

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -17,6 +17,11 @@
                     {{ end }}
                 </div>
             {{ end }}
+        {{ if .Site.Params.themeToggle }}
+        <button id="theme-toggle" aria-label="Toggle theme" class="menu-item theme-toggle-btn">
+            <span class="theme-icon">🌙</span>
+        </button>
+        {{ end }}
         </nav>
     </div>
 </header>

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -19,7 +19,7 @@
             {{ end }}
         {{ if .Site.Params.themeToggle }}
         <button id="theme-toggle" aria-label="Toggle theme" class="menu-item theme-toggle-btn">
-            <span class="theme-icon">🌙</span>
+            <span class="theme-icon">➖</span>
         </button>
         {{ end }}
         </nav>

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -17,11 +17,6 @@
                     {{ end }}
                 </div>
             {{ end }}
-        {{ if .Site.Params.themeToggle }}
-        <button id="theme-toggle" aria-label="Toggle theme" class="menu-item theme-toggle-btn">
-            <span class="theme-icon">➖</span>
-        </button>
-        {{ end }}
         </nav>
     </div>
 </header>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="theme-{{ .Site.Params.themeMode | default "auto" }}">
     <head>
         {{ partial "head.html" . }}
     </head>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -78,6 +78,44 @@
   }
 }
 
+html.theme-light:root {
+  --color-bg-page:                  var(--color-light-bg-page);
+  --color-bg-content:               var(--color-light-bg-content);
+  --color-bg-block:                 var(--color-light-bg-block);
+  --color-bg-shadow:                var(--color-light-bg-shadow);
+  --color-fg-font-normal:           var(--color-light-fg-font-normal);
+  --color-fg-font-hover:            var(--color-light-fg-font-hover);
+  --color-fg-font-quote:            var(--color-light-fg-font-quote);
+  --color-fg-tiny-line:             var(--color-light-fg-tiny-line);
+  --color-fg-marker-quote:          var(--color-light-fg-marker-quote);
+  --color-fg-font-hyper:            var(--color-light-fg-font-hyper);
+  --color-fg-font-hyper-hover:      var(--color-light-fg-font-hyper-hover);
+  --color-fg-hyperlink:             var(--color-light-fg-hyperlink);
+  --color-fg-hyperlink-hover:       var(--color-light-fg-hyperlink-hover);
+  --color-bg-pager-normal:          var(--color-light-bg-pager-normal);
+  --color-bg-pager-current:         var(--color-light-bg-pager-current);
+  --color-bg-pager-hover:           var(--color-light-bg-pager-hover);
+}
+
+html.theme-dark:root {
+  --color-bg-page:                var(--color-dark-bg-page);
+  --color-bg-content:             var(--color-dark-bg-content);
+  --color-bg-block:               var(--color-dark-bg-block);
+  --color-bg-shadow:              var(--color-dark-bg-shadow);
+  --color-fg-font-normal:         var(--color-dark-fg-font-normal);
+  --color-fg-font-hover:          var(--color-dark-fg-font-hover);
+  --color-fg-font-quote:          var(--color-dark-fg-font-quote);
+  --color-fg-tiny-line:           var(--color-dark-fg-tiny-line);
+  --color-fg-marker-quote:        var(--color-dark-fg-marker-quote);
+  --color-fg-font-hyper:          var(--color-dark-fg-font-hyper);
+  --color-fg-font-hyper-hover:    var(--color-dark-fg-font-hyper-hover);
+  --color-fg-hyperlink:           var(--color-dark-fg-hyperlink);
+  --color-fg-hyperlink-hover:     var(--color-dark-fg-hyperlink-hover);
+  --color-bg-pager-normal:        var(--color-dark-bg-pager-normal);
+  --color-bg-pager-current:       var(--color-dark-bg-pager-current);
+  --color-bg-pager-hover:         var(--color-dark-bg-pager-hover);
+}
+
 :root {
   --fonts-sans-en: "Noto Sans", "Droid Sans", "Calibri", "Arial";
   --fonts-sans-zh: "WenQuanYi Zen Hei", "WenQuanYi Micro Hei",
@@ -708,6 +746,23 @@ pre .copyCodeButton:hover {
 
 .commenting {
   width: 85%;
+}
+
+/***************************/
+/* theme toggle properties */
+/***************************/
+
+.theme-toggle-btn {
+  background: none;
+  border: 2px solid var(--color-fg-font-normal);
+  padding: 6px 6px;
+  cursor: pointer;
+  font-size: 1.2em;
+  border-radius: 8px;
+}
+
+.theme-toggle-btn:hover {
+  opacity: 0.7;
 }
 
 /**********/

--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -1,0 +1,42 @@
+function initThemeToggle() {
+  const html = document.documentElement;
+  const button = document.getElementById("theme-toggle");
+  const icon = button.querySelector(".theme-icon");
+
+  // Get saved preference or current theme
+  function getCurrentTheme() {
+    const saved = localStorage.getItem("themeMode");
+    if (saved) return saved;
+
+    // Check current class (set by Hugo)
+    if (html.classList.contains("theme-light")) return "light";
+    if (html.classList.contains("theme-dark")) return "dark";
+    return "light"; // fallback
+  }
+
+  // Apply theme and update icon
+  function applyTheme(theme) {
+    html.classList.remove("theme-light", "theme-dark");
+    html.classList.add("theme-" + theme);
+
+    updateIcon(theme);
+    localStorage.setItem("themeMode", theme);
+  }
+
+  // Update icon to match current theme
+  function updateIcon(theme) {
+    icon.textContent = theme === "dark" ? "🌙" : "☀️";
+  }
+
+  // Toggle: light ↔ dark
+  button.addEventListener("click", () => {
+    const current = getCurrentTheme();
+    const next = current === "light" ? "dark" : "light";
+    applyTheme(next);
+  });
+
+  // Set initial icon
+  updateIcon(getCurrentTheme());
+}
+
+document.addEventListener("DOMContentLoaded", initThemeToggle);

--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -1,42 +1,52 @@
 function initThemeToggle() {
-  const html = document.documentElement;
-  const button = document.getElementById("theme-toggle");
-  const icon = button.querySelector(".theme-icon");
+  const menuNav = document.querySelector("nav.menu");
+  if (!menuNav) return;
 
-  // Get saved preference or current theme
+  // Create button
+  const button = document.createElement("button");
+  button.id = "theme-toggle";
+  button.className = "menu-item theme-toggle-btn";
+  button.setAttribute("aria-label", "Toggle theme");
+
+  const icon = document.createElement("span");
+  icon.className = "theme-icon";
+  button.appendChild(icon);
+
+  menuNav.appendChild(button);
+
+  const html = document.documentElement;
+
   function getCurrentTheme() {
+    // Check localStorage FIRST
     const saved = localStorage.getItem("themeMode");
     if (saved) return saved;
 
-    // Check current class (set by Hugo)
+    // Then check Hugo-set class
     if (html.classList.contains("theme-light")) return "light";
     if (html.classList.contains("theme-dark")) return "dark";
-    return "light"; // fallback
+    return "light";
   }
 
-  // Apply theme and update icon
-  function applyTheme(theme) {
-    html.classList.remove("theme-light", "theme-dark");
-    html.classList.add("theme-" + theme);
-
-    updateIcon(theme);
-    localStorage.setItem("themeMode", theme);
-  }
-
-  // Update icon to match current theme
   function updateIcon(theme) {
     icon.textContent = theme === "dark" ? "🌙" : "☀️";
   }
 
-  // Toggle: light ↔ dark
+  function applyTheme(theme) {
+    html.classList.remove("theme-light", "theme-dark");
+    html.classList.add("theme-" + theme);
+    updateIcon(theme);
+    localStorage.setItem("themeMode", theme);
+  }
+
+  // Apply saved preference immediately on load
+  const currentTheme = getCurrentTheme();
+  applyTheme(currentTheme);
+
   button.addEventListener("click", () => {
     const current = getCurrentTheme();
     const next = current === "light" ? "dark" : "light";
     applyTheme(next);
   });
-
-  // Set initial icon
-  updateIcon(getCurrentTheme());
 }
 
 document.addEventListener("DOMContentLoaded", initThemeToggle);


### PR DESCRIPTION
Currently, light or dark theme is automatically set based on browser defaults.

This PR allows the theme to be forced to light or dark in the site config. It also adds an option to have a button for the user to toggle between light and dark theme. The toggle is off by default and the automatic detection also remains the default, so default behavior is unchanged.